### PR TITLE
not supported os version now returns failure

### DIFF
--- a/android/src/main/java/co/eleken/react_native_touch_id_android/FingerprintModule.java
+++ b/android/src/main/java/co/eleken/react_native_touch_id_android/FingerprintModule.java
@@ -111,6 +111,8 @@ public class FingerprintModule extends ReactContextBaseJavaModule {
             } else {
                 sendResponse("failed", "You don\'t have appropriate hardware", promise);
             }
+        } else {
+            sendResponse("failed", "You don\'t have appropriate hardware", promise);
         }
     }
     


### PR DESCRIPTION
When a OS version doesn't support TouchId we should return a failure.
In my case I noticed that because on some devices the call to "isSensorAvailable" hangs and never returns...

It's my first pull request, i hope i didn't messed up...